### PR TITLE
Updating URL to  point directly to page with v2 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 
 * Use of this addon requires a Developer License from LeapMotion see: https://www.leapmotion.com/developers
 
-* Once registered you should download and install the latest Leap Software from https://beta.leapmotion.com/ 
+* Once registered you should download and install the latest Leap Software from https://developer.leapmotion.com/sdk/v2 
 
 * To use ofxLeapMotion, first you need to download and install [openFrameworks](https://github.com/openframeworks/openFrameworks).
 


### PR DESCRIPTION
Updating the URL for Leap SDK to point directly to the page with the SDK. Currently, Leap is pushing their new VR focused SDK which is  Windows only.