### PR TITLE
Making it work with openFrameworks 0.10

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -5,41 +5,41 @@ meta:
 common:
 	# dependencies with other addons, a list of them separated by spaces 
 	# or use += in several lines
-	ADDON_DEPENDENCIES =
+	# ADDON_DEPENDENCIES =
 	
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES =
+	# ADDON_INCLUDES =
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon
-	ADDON_CFLAGS = 
+	# ADDON_CFLAGS = 
 	
 	# any special flag that should be passed to the linker when using this
 	# addon, also used for system libraries with -lname
-	ADDON_LDFLAGS = 
+	# ADDON_LDFLAGS = 
 	
 	# linux only, any library that should be included in the project using
 	# pkg-config
-	ADDON_PKG_CONFIG_LIBRARIES =
+	# ADDON_PKG_CONFIG_LIBRARIES =
 	
 	# osx/iOS only, any framework that should be included in the project
-	ADDON_FRAMEWORKS =
+	# ADDON_FRAMEWORKS =
 	
 	# source files, these will be usually parsed from the file system looking
 	# in the src folders in libs and the root of the addon. if your addon needs
 	# to include files in different places or a different set of files per platform
 	# they can be specified here
-	ADDON_SOURCES =
+	# ADDON_SOURCES =
 	
 	# some addons need resources to be copied to the bin/data folder of the project
 	# specify here any files that need to be copied, you can use wildcards like * and ?
-	ADDON_DATA = 
+	# ADDON_DATA = 
 	
 	# when parsing the file system looking for libraries exclude this for all or
 	# a specific platform
-	ADDON_LIBS_EXCLUDE =
+	# ADDON_LIBS_EXCLUDE =
 	
 
 linux:

--- a/example/src/ofxStrip/ofxStrip.h
+++ b/example/src/ofxStrip/ofxStrip.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "ofMesh.h"
+#include "ofPoint.h"
 
 class ofxStrip{
 
@@ -25,13 +26,13 @@ class ofxStrip{
 			tex_v = tex_v_scale;
 		}
 		
-		void generate( vector <ofPoint> pts, float fixedWidth, ofPoint upVec){
-			vector <float> width;
+		void generate( std::vector <glm::vec3> pts, float fixedWidth, ofPoint upVec){
+			std::vector <float> width;
 			width.push_back(fixedWidth);
 			generate( pts, width, upVec);
 		} 
 		
-		void generate( vector <ofPoint> pts, vector <float> width, ofPoint upVec){
+		void generate( std::vector <glm::vec3> pts, std::vector <float> width, ofPoint upVec){
 			bool  bFixedWidth = false; 
 			float curWidth; 
 			float maxWidth = 0; 
@@ -62,11 +63,11 @@ class ofxStrip{
 				}
 				
 				//find this point and the next point
-				ofVec3f & thisPoint = pts[i-1];
-				ofVec3f & nextPoint = pts[i];
+				glm::vec3 & thisPoint = pts[i-1];
+				glm::vec3 & nextPoint = pts[i];
 				
 				ofPoint delta		= nextPoint - thisPoint; 
-				ofPoint deltaNorm	= delta.normalized();
+				ofPoint deltaNorm	= delta.getNormalized();
 				
 				ofVec3f toTheLeft	= deltaNorm.getPerpendicular(upVec);
 								

--- a/src/ofxLeapMotion.cpp
+++ b/src/ofxLeapMotion.cpp
@@ -292,7 +292,7 @@ void ofxLeapMotion::onDeviceChange(const Controller& contr){
 vector <Hand> ofxLeapMotion::getLeapHands(){
 
 	vector <Hand> handsCopy; 
-	if(ourMutex.tryLock(2000)){
+	if(ourMutex.try_lock()){
 		handsCopy = hands; 
 		ourMutex.unlock();
 	}

--- a/src/ofxLeapMotion.h
+++ b/src/ofxLeapMotion.h
@@ -6,7 +6,6 @@
 
 #include "ofMain.h"
 #include "Leap.h"
-#include "Poco/Mutex.h"
 
 using namespace Leap;
 
@@ -150,5 +149,5 @@ class ofxLeapMotion : public Listener{
 		// TODO: added for Gesture support - JRW
 		Leap::Frame lastFrame;
 		
-		Poco::FastMutex ourMutex;
+        std::mutex ourMutex;
 };


### PR DESCRIPTION
Changed the Poco::FastMutex into an std::mutex so it works in openFrameworks 0.10

Also fixed the addon_config.mk so the addon gets linked correctly when generating a project. Previously I had to create the ofxLeapMotion group and add the src and libs. Still needs the Run Script phase though.

Tested & works on openFrameworks 0.10 on OSX Mojave, XCode 10.